### PR TITLE
start-base64url

### DIFF
--- a/src/fernet.app.src
+++ b/src/fernet.app.src
@@ -8,7 +8,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  base64url
                  ]},
   {env, []}
  ]}.


### PR DESCRIPTION
Start `base64url` app when `fernet` is started.  I had to add
`base64url` to my app's `applications` list when I tried to use
`fernet`.  I guess this will fix the issue.
