### PR TITLE
hex-package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,3 +16,5 @@
 {overrides, [
     {override, pkcs7, [{deps, []}]}
 ]}.
+
+{plugins, [{rebar3_hex, "0.5.1"}]}.

--- a/src/fernet.app.src
+++ b/src/fernet.app.src
@@ -12,5 +12,8 @@
                   base64url,
                   pkcs7
                  ]},
-  {env, []}
+  {env, []},
+  {contributors, ["Kevin McDermott", "Fred Hebert", "Jamu Kakar"]},
+  {licenses, []},
+  {links, [{"Github", "https://github.com/bigkevmcd/erlfernet"}]}
  ]}.


### PR DESCRIPTION
Add `rebar3_hex` plugin and minimal app configuration changes to
publish a Hex package.  I think this is the bare minimum needed for
`rebar3 hex publish` to work (but I haven't tested it).
